### PR TITLE
solution for Github issue 71

### DIFF
--- a/referencesrv/parser/crf.py
+++ b/referencesrv/parser/crf.py
@@ -39,7 +39,7 @@ class CRFClassifierText(object):
                                     re.compile(r'([A-Z])(\-)([A-Z])\b')]
 
     URL_EXTRACTOR = re.compile(r'((url\s*)?(http)s?://[A-z0-9\-\.\/\={}?&%]+)', re.IGNORECASE)
-    MONTH_NAME_EXTRACTOR = re.compile(r'\b([Jj]an(?:uary)?|[Ff]eb(?:ruary)?|[Mm]ar(?:ch)?|[Aa]pr(?:il)?|[Mm]ay|[Jj]un(?:e)?|[Jj]ul(?:y)?|[Aa]ug(?:ust)?|[Ss]ep(?:tember)?|[Oo]ct(?:ober)?|([Nn]ov|[Dd]ec)(?:ember)?)\b')
+    MONTH_NAME_EXTRACTOR = re.compile(r'\b([Jj]an(?:uary)?|[Ff]eb(?:ruary)?|[Mm]ar(?:ch)?|[Aa]pr(?:il)?|[Mm]ay|[Jj]un(?:e)?|[Jj]ul(?:y)?|[Aa]ug(?:ust)?|[Ss]ep(?:tember)?|[Oo]ct(?:ober)?|([Nn]ov|[Dd]ec)(?:ember)?)\b(?!-)')
 
     URL_TO_DOI = re.compile(r'((url\s*)?(https\s*:\s*//\s*|http\s*:\s*//\s*)((.*?)doi(.*?)org/))|(DOI:https\s*://\s*)', flags=re.IGNORECASE)
     URL_TO_ARXIV = re.compile(r'((url\s*)?(https://|http://)(arxiv.org/(abs|pdf)/))', flags=re.IGNORECASE)


### PR DESCRIPTION
This change deals with the problem described in issue #71. The problem is caused by date strings of the form `Jun-2024`. The regular expression in the `crf.py` parser includes the year with the tag `|na_month|` (as described in the issue). The logic is such that when a month is detected, using the regular expression, code expects the tag to be present in the `ref_words` list and therefore expects to be able to get the location of the tag in the list through `ref_words.index('|na_month|')`. 

The solution is to make the regular expression ignore month expressions directly followed by a hyphen. Having the month really is not all the crucial anyway for matching references.